### PR TITLE
Fix Gentoo Forums latest post and date parsing

### DIFF
--- a/phpbb2rss.go
+++ b/phpbb2rss.go
@@ -89,6 +89,9 @@ Pages: {{.Pages}}`
 		title := strings.TrimSpace(topic.Text())
 		topicLink, topicExists := topic.Attr("href")
 		latestPostLink, latestPostExists := s.Find("a:contains('View latest post')").Attr("href")
+		if !latestPostExists {
+			latestPostLink, latestPostExists = s.Find("a:has(img[alt='View latest post'])").Attr("href")
+		}
 		if !topicExists || title == "" {
 			return
 		}
@@ -116,7 +119,7 @@ Pages: {{.Pages}}`
 			guid = latestPostURL.String()
 		}
 
-		pubDateRaw := strings.TrimSpace(s.Find(".postdetails").Last().Text())
+		pubDateRaw := strings.TrimSpace(s.Find(".postdetails").Last().Contents().First().Text())
 		parsedDate, err := time.Parse("Mon Jan 02, 2006 3:04 pm", pubDateRaw)
 		if err != nil {
 			parsedDate = time.Now()


### PR DESCRIPTION
Updates to the DOM parsing logic to ensure `phpbb2rss` works properly with Gentoo Forums.

Changes:
1. Re-implemented the latest post extraction logic: Since Gentoo forums use an image with an alt tag "View latest post" instead of the text itself, the parser now checks for an `a` tag containing `img[alt='View latest post']` if the initial text check fails.
2. Fixed date parsing: Extracted only the first text node of the `.postdetails` element to get the correct date string. Previously, appending text from other nested elements (e.g. the author's name) caused the `time.Parse` function to error out and fall back to `time.Now()`.

---
*PR created automatically by Jules for task [10518333762551150346](https://jules.google.com/task/10518333762551150346) started by @arran4*