### PR TITLE
ci: upgrade goreleaser-action to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
Upgrades the goreleaser-action version in the CI workflow from v5 to v6 to support version 2 goreleaser configurations.

---
*PR created automatically by Jules for task [11275627520985122090](https://jules.google.com/task/11275627520985122090) started by @arran4*