### PR TITLE
ci: fix goreleaser git tag validation error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/go_releaser.yaml
+++ b/.github/workflows/go_releaser.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       -
         name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Fix GoReleaser error: `git tag vX.Y.Z was not made against commit ...`

This is caused by `actions/checkout@v4` changing its default behavior regarding fetching tags when `fetch-depth: 0` is specified. Adding `fetch-tags: true` explicitly instructs the action to fetch tags, allowing GoReleaser to correctly identify the tag matching the current commit and proceed without validation errors.

This change is applied to both the dedicated `go_releaser.yaml` and the overall `ci.yml` workflows.

---
*PR created automatically by Jules for task [9440877879599940341](https://jules.google.com/task/9440877879599940341) started by @arran4*