### PR TITLE
ci: Gracefully handle non-tag runs in GoReleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          args: ${{ startsWith(github.ref, 'refs/tags/') && 'release --clean' || 'release --clean --snapshot' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fixes GoReleaser validation failing on untagged commits in `ci.yml`.

---
*PR created automatically by Jules for task [2599470895733088299](https://jules.google.com/task/2599470895733088299) started by @arran4*