### PR TITLE
feat: output forum sections as RSS categories

### DIFF
--- a/phpbb2rss.go
+++ b/phpbb2rss.go
@@ -32,6 +32,7 @@ type Item struct {
 	PubDate     string `xml:"pubDate"`
 	GUID        string `xml:"guid"`
 	Author      string `xml:"author"`
+	Category    string `xml:"category,omitempty"`
 }
 
 func FetchAndGenerateRSS(forumURL string) (string, error) {
@@ -197,6 +198,7 @@ func parsePHPBB2(doc *goquery.Document, baseURL *url.URL, tmpl *template.Templat
 			PubDate:     parsedDate.Format(time.RFC1123),
 			GUID:        guid,
 			Author:      author,
+			Category:    category,
 		})
 	})
 	return items
@@ -305,6 +307,7 @@ func parsePHPBB3(doc *goquery.Document, baseURL *url.URL, tmpl *template.Templat
 			PubDate:     parsedDate.Format(time.RFC1123),
 			GUID:        guid,
 			Author:      author,
+			Category:    category,
 		})
 	})
 	return items

--- a/phpbb2rss_test.go
+++ b/phpbb2rss_test.go
@@ -45,6 +45,9 @@ func TestParsePHPBB2(t *testing.T) {
 	if !strings.Contains(rss, "OldAuthor") {
 		t.Errorf("Expected RSS to contain 'OldAuthor'")
 	}
+	if !strings.Contains(rss, "<category>Old Category</category>") {
+		t.Errorf("Expected RSS to contain '<category>Old Category</category>', got: %s", rss)
+	}
 }
 
 func TestParsePHPBB3(t *testing.T) {
@@ -93,5 +96,8 @@ func TestParsePHPBB3(t *testing.T) {
 	}
 	if !strings.Contains(rss, "NewAuthor") {
 		t.Errorf("Expected RSS to contain 'NewAuthor'")
+	}
+	if !strings.Contains(rss, "<category>New Category</category>") {
+		t.Errorf("Expected RSS to contain '<category>New Category</category>', got: %s", rss)
 	}
 }


### PR DESCRIPTION
Added a `<category>` element mapping for items output in the RSS feed. The category already extracted for the description is now properly output as an XML standard element. Tested and built.

---
*PR created automatically by Jules for task [14440819074308925281](https://jules.google.com/task/14440819074308925281) started by @arran4*