### PR TITLE
Fix `pages.yml` workflow by adding required `-url` flag

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,7 +43,11 @@ jobs:
           cat readme.html >> public/index.html
           echo '</html>' >> public/index.html
           # Generate RSS feed
-          go run ./cmd/phpbb2rss -output public/rss/phpbb2rss.xml
+          if [ -n "${{ vars.FORUM_URL }}" ]; then
+            go run ./cmd/phpbb2rss -output public/rss/phpbb2rss.xml -url "${{ vars.FORUM_URL }}"
+          else
+            echo "Warning: FORUM_URL variable is not set. Skipping RSS generation."
+          fi
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
Fixes the failing `build-and-deploy` job in the `pages.yml` workflow. The `phpbb2rss` CLI requires a `-url` flag, which was missing. This update adds a check for the `FORUM_URL` repository variable and passes it to the CLI if present, or skips RSS generation with a warning if not set.

---
*PR created automatically by Jules for task [8859287873037864779](https://jules.google.com/task/8859287873037864779) started by @arran4*