### PR TITLE
Fix manual-gh-release pipeline job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,7 +494,7 @@ jobs:
           gh release create "$TAG" --generate-notes $prerelease || true
         else
           gh release create "$TAG" --generate-notes $discussion_arg || \
-            gh release create "$TAG" --generate-notes
+            gh release create "$TAG" --generate-notes || true
         fi
 
   publish-draft:


### PR DESCRIPTION
Added `|| true` to the fallback `gh release create` command in the `manual-gh-release` job. This prevents the pipeline from failing with HTTP 422 ("Release.tag_name already exists") if the concurrent `goreleaser` job has already created the release for the tag. It also handles cases where discussions are disabled, which previously caused a 404.

---
*PR created automatically by Jules for task [10030161537767919583](https://jules.google.com/task/10030161537767919583) started by @arran4*